### PR TITLE
fix invalid npm package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,42 @@
 {
   "name": "Streams",
-  "version": "1.0",
+  "version": "1.0.0",
   "description": "Lazy streams.",
-  "maintainers": [{
-    "name": "Dionysis Zindros",
-    "email": "dionyziz@gmail.com",
-    "web": "http://dionyziz.com/"
-  }],
-  "contributors": [{
-    "name": "Ryan Scheel",
-    "email": "ryan.havvy@gmail.com",
-    "web": "http://widget.mibbit.com/?channel=%23havvy&server=irc.mibbit.net"
+  "repository": {
+    "git": "https://github.com/dionyziz/stream.js"
   },
-  {
-    "name": "Dionysis Zindros",
-    "email": "dionyziz@gmail.com",
-    "web": "http://dionyziz.com/"
-  }],
-  "main": "lib",
-  "directories": ["lib"],
+  "home": "http://streamjs.org/",
+  "license": "MIT",
+  "maintainers": [
+    {
+      "name": "Dionysis Zindros",
+      "email": "dionyziz@gmail.com",
+      "web": "http://dionyziz.com/"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "Ryan Scheel",
+      "email": "ryan.havvy@gmail.com",
+      "web": "http://widget.mibbit.com/?channel=%23havvy&server=irc.mibbit.net"
+    },
+    {
+      "name": "Dionysis Zindros",
+      "email": "dionyziz@gmail.com",
+      "web": "http://dionyziz.com/"
+    }
+  ],
+  "main": "lib/index.js",
+  "directories": {
+    "lib": "lib"
+  },
   "engines": {
     "node": ">=0.4.0"
   },
-  "keywords": ["stream", "lazy", "infinite", "data structure"]
+  "keywords": [
+    "stream",
+    "lazy",
+    "infinite",
+    "data structure"
+  ]
 }


### PR DESCRIPTION
the current `package.json` had several issues and was not a valid package for npm.
 The following sections was wrong:

+ [directories](https://docs.npmjs.com/files/package.json#directories) must be an object
+ [license was missing](https://npm1k.org/)
+ version number was not semver (invalid)
+ home was missing

test is also missing but I'm guessing test framework here. It could be jasmine but who knows?