### PR TITLE
test framework - fix invalid npm package.json - part II

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .project
-
+node_modules

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     }
   ],
   "main": "lib/index.js",
+  "scripts": {
+    "test": "jasmine"
+  },
   "directories": {
     "lib": "lib"
   },
@@ -38,5 +41,8 @@
     "lazy",
     "infinite",
     "data structure"
-  ]
+  ],
+  "devDependencies": {
+    "jasmine": "^2.3.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,26 +1,42 @@
 {
   "name": "Streams",
-  "version": "1.0",
+  "version": "1.0.0",
   "description": "Lazy streams.",
-  "maintainers": [{
-    "name": "Dionysis Zindros",
-    "email": "dionyziz@gmail.com",
-    "web": "http://dionyziz.com/"
-  }],
-  "contributors": [{
-    "name": "Ryan Scheel",
-    "email": "ryan.havvy@gmail.com",
-    "web": "http://widget.mibbit.com/?channel=%23havvy&server=irc.mibbit.net"
+  "repository": {
+    "git": "https://github.com/dionyziz/stream.js"
   },
-  {
-    "name": "Dionysis Zindros",
-    "email": "dionyziz@gmail.com",
-    "web": "http://dionyziz.com/"
-  }],
-  "main": "lib",
-  "directories": ["lib"],
+  "home": "http://streamjs.org/",
+  "license": "MIT",
+  "maintainers": [
+    {
+      "name": "Dionysis Zindros",
+      "email": "dionyziz@gmail.com",
+      "web": "http://dionyziz.com/"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "Ryan Scheel",
+      "email": "ryan.havvy@gmail.com",
+      "web": "http://widget.mibbit.com/?channel=%23havvy&server=irc.mibbit.net"
+    },
+    {
+      "name": "Dionysis Zindros",
+      "email": "dionyziz@gmail.com",
+      "web": "http://dionyziz.com/"
+    }
+  ],
+  "main": "lib/index.js",
+  "directories": {
+    "lib": "lib"
+  },
   "engines": {
     "node": ">=0.4.0"
   },
-  "keywords": ["stream", "lazy", "infinite", "data structure"]
+  "keywords": [
+    "stream",
+    "lazy",
+    "infinite",
+    "data structure"
+  ]
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,9 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ]
+}


### PR DESCRIPTION
[Jasmine](https://github.com/jasmine/jasmine-npm) will run the test suit, so here is a **package.json** that enable the `npm test` command. And make it possible to use travis #15.

Note that one test is failing. I haven't looked into why as it doesn't stop us for using travis. It just means we have a failing test.