### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#stream.js [![Build Status](https://travis-ci.org/dionyziz/stream.js.svg?branch=master)](https://travis-ci.org/dionyziz/stream.js) [![codecov.io](https://codecov.io/github/dionyziz/stream.js/coverage.svg?branch=master)](https://codecov.io/github/dionyziz/stream.js?branch=master)
+# stream.js [![Build Status](https://travis-ci.org/dionyziz/stream.js.svg?branch=master)](https://travis-ci.org/dionyziz/stream.js) [![codecov.io](https://codecov.io/github/dionyziz/stream.js/coverage.svg?branch=master)](https://codecov.io/github/dionyziz/stream.js?branch=master)
 
 stream.js is a tiny Javascript library that unlocks a new data structure for you: streams.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
