### PR TITLE
Make stream iterable

### DIFF
--- a/spec/stream.spec.js
+++ b/spec/stream.spec.js
@@ -451,3 +451,14 @@ describe('Eager streams', () => {
     expect(powersOfTwo.item(10)).toBe(1024);
   });
 });
+
+describe('Iteratable stream', () => {
+  it('should provide an iterator', () => {
+    const stream = Stream.make(1, 2, 3);
+    const iterator = stream[Symbol.iterator]();
+    expect(iterator.next().value).toBe(1);
+    expect(iterator.next().value).toBe(2);
+    expect(iterator.next().value).toBe(3);
+    expect(iterator.next().value).toBe(undefined);
+  });
+});

--- a/spec/stream.spec.js
+++ b/spec/stream.spec.js
@@ -461,4 +461,13 @@ describe('Iteratable stream', () => {
     expect(iterator.next().value).toBe(3);
     expect(iterator.next().value).toBe(undefined);
   });
+
+  it('should eventually stop looping', () => {
+    const stream = Stream.make(1, 2, 3);
+
+    // eslint-disable-next-line
+    for (const value of stream) {
+      expect(value).toBeDefined();
+    }
+  });
 });

--- a/src/stream.js
+++ b/src/stream.js
@@ -303,6 +303,21 @@ Stream.prototype = {
     // requires finite stream
     return '[stream head: ' + this.head() + '; tail: ' + this.tail() + ']';
   },
+  [Symbol.iterator]: function () {
+    let self = this;
+    return {
+      next() {
+        if (self.empty()) {
+          return { value: undefined, done: true };
+        }
+
+        const head = self.head();
+        self = self.tail();
+
+        return { value: head, done: false };
+      },
+    };
+  },
 };
 
 function _continually(callback, wrapper) {


### PR DESCRIPTION
This change allows users to loop through the stream using the ES6 `for..of` loop